### PR TITLE
Fix issue with not asking for output file path

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -82,6 +82,7 @@ int main()
             {
                 cout << "Enter name for file : ";
                 string path2;
+                cin.ignore();
                 std::getline(cin, path2);
                 ofstream MyFile(path2.c_str());
                 if (!(MyFile))


### PR DESCRIPTION
You're missing a `cin.ignore()` before the `std::getline()` when asking for the output file path. The program would just not ask for input and quit with an error.